### PR TITLE
Mention go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ The `airscan` Go package can be used to scan paper documents 📄 from a scanner
 First, install the example program coming with this package:
 
 ```
-go get github.com/stapelberg/airscan/cmd/airscan1
-go install github.com/stapelberg/airscan/cmd/airscan1
+go get -v github.com/stapelberg/airscan/cmd/airscan1
 ```
 
 Then, query the local network for AirScan compatible devices:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The `airscan` Go package can be used to scan paper documents 📄 from a scanner
 First, install the example program coming with this package:
 
 ```
+go get github.com/stapelberg/airscan/cmd/airscan1
 go install github.com/stapelberg/airscan/cmd/airscan1
 ```
 


### PR DESCRIPTION
Steps as per README.md lead to:

```
me@host:~$ '/home/me/Downloads/go/bin/go' install github.com/stapelberg/airscan/cmd/airscan1
cannot find package "github.com/stapelberg/airscan/cmd/airscan1" in any of:
	/home/me/Downloads/go/src/github.com/stapelberg/airscan/cmd/airscan1 (from $GOROOT)
	/home/me/go/src/github.com/stapelberg/airscan/cmd/airscan1 (from $GOPATH)
```

But this works:

```
me@host:~$ '/home/me/Downloads/go/bin/go' get  github.com/stapelberg/airscan/cmd/airscan1
me@host:~$ '/home/me/Downloads/go/bin/go' install github.com/stapelberg/airscan/cmd/airscan1
```