### PR TITLE
Add a compatible printer, and add a few airscan1 flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ your report in this table for the benefit of other interested users:
 | Device Name | Working features | Known issues |
 | ----------- | ---------------- | ------------ |
 | Brother MFC-L2750DW | flat bed scan, automatic document feeder scan | |
+| HP Laserjet M479fdw | flat bed scan, automatic document feeder scan | |


### PR DESCRIPTION
The airscan package works with my HP Laserjet M479fdw! I had to adjust airscan1 a bit to scan pages in US letter format, and while I was in there I also added a way to request PDF output format, since that's how I keep my digitized paper :)