### PR TITLE
Control duplex setting in airscan1

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ your report in this table for the benefit of other interested users:
 | ----------- | ---------------- | ------------ |
 | Brother MFC-L2750DW | flat bed scan, automatic document feeder scan | |
 | HP Laserjet M479fdw | flat bed scan, automatic document feeder scan | |
+| Brother MFC-L2710DN | flat bed scan, automatic document feeder scan | must be run with -duplex=false |

--- a/cmd/airscan1/airscan1.go
+++ b/cmd/airscan1/airscan1.go
@@ -86,6 +86,12 @@ func airscan1() error {
 		"image/jpeg",
 		"File format to request from the scanner")
 
+	flag.BoolVar(
+		&sc.duplex,
+		"duplex",
+		true,
+		"if false, scan only the front side of the page")
+
 	var (
 		discover = flag.Duration("discover",
 			0,
@@ -184,6 +190,7 @@ type airscanner struct {
 	source  string
 	size    string
 	format  string
+	duplex  bool
 	service *dnssd.Service
 }
 
@@ -213,6 +220,8 @@ func (sc *airscanner) scan1() error {
 		suffix = "pdf"
 		settings.DocumentFormat = "application/pdf"
 	}
+	settings.Duplex = sc.duplex
+
 	scan, err := cl.Scan(settings)
 	if err != nil {
 		return err


### PR DESCRIPTION
This pull request brings support for toggling the duplex setting. My scanner would not use the ADF source when `scan:Duplex` was set to `true` and would always revert to using the flatbed. For simplex scanners, this setting should be set to `false`.