### PR TITLE
Support setting color mode and update documentation accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Now, I can scan the contents of the flatbed scanner:
 2020/08/16 11:10:47 scan done in 13.068799513s
 ```
 
+…or the page(s) from ADF, colored, and as single PDF file output:
+```
+% airscan1 -host=HPFXXXXXXXXXXXX -source adf -color RGB24 -format "application/pdf"
+2021/04/04 00:12:13 finding device for 5s (use -timeout=0 for unlimited)
+2021/04/04 00:12:14 device "HP OfficeJet Pro 9010 series" found in 315.486148ms
+2021/04/04 00:14:07 wrote /tmp/page5.pdf (123456 bytes)
+2021/04/04 00:14:07 scan done in 1m53.772520178s
+```
+
 ## Getting started: using the package in your program
 
 See the [package airscan examples in

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ your report in this table for the benefit of other interested users:
 | Brother MFC-L2750DW | flat bed scan, automatic document feeder scan | |
 | HP Laserjet M479fdw | flat bed scan, automatic document feeder scan | |
 | Brother MFC-L2710DN | flat bed scan, automatic document feeder scan | must be run with -duplex=false |
+| HP OfficeJet Pro 9010 series | flat bed scan, automatic document feeder scan | |

--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ your report in this table for the benefit of other interested users:
 | Brother MFC-L2750DW | flat bed scan, automatic document feeder scan | |
 | HP Laserjet M479fdw | flat bed scan, automatic document feeder scan | |
 | Brother MFC-L2710DN | flat bed scan, automatic document feeder scan | must be run with -duplex=false |
-| HP OfficeJet Pro 9010 series | flat bed scan, automatic document feeder scan | |
+| HP OfficeJet Pro 9010 series | flat bed scan, automatic document feeder scan, color: RGB24 | |

--- a/cmd/airscan1/airscan1.go
+++ b/cmd/airscan1/airscan1.go
@@ -86,6 +86,12 @@ func airscan1() error {
 		"image/jpeg",
 		"File format to request from the scanner")
 
+	flag.StringVar(
+		&sc.color,
+		"color",
+		"Grayscale8",
+		"Color mode to request from the scanner (Grayscale8, RGB24)")
+
 	flag.BoolVar(
 		&sc.duplex,
 		"duplex",
@@ -190,6 +196,7 @@ type airscanner struct {
 	source  string
 	size    string
 	format  string
+	color   string
 	duplex  bool
 	service *dnssd.Service
 }
@@ -219,6 +226,11 @@ func (sc *airscanner) scan1() error {
 	case "application/pdf":
 		suffix = "pdf"
 		settings.DocumentFormat = "application/pdf"
+	}
+	switch sc.color {
+	case "Grayscale8":
+	case "RGB24":
+		settings.ColorMode = "RGB24"
 	}
 	settings.Duplex = sc.duplex
 


### PR DESCRIPTION
The "RGB24" value was taken from ftp://ftp.pwg.org/pub/pwg/mfd/wd/wd-mfdmodel10-20110124.pdf found via http://www.pwg.org/schemas/2010/12/sm found via `preset/preset.go`- though I don't know if that is the most up-to-date document, the value "RGB24" is the only one I tested and it worked well with my scanner. I did not test case-sensitivity. Just "RGB" did not work.

(I don't know if this message will appear in the commit message; if so, feel free to edit/remove, but) I wanted to say thanks for this tool! So far I have been using simple-scan on Debian, but I could not get duplex scanning to work. With this tool, things "just worked", great!

I started drafting this PR before seeing #5, but I suppose this closes #5. 